### PR TITLE
Fix some typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ run-polars: .venv data/tables/  ## Run Polars benchmarks
 	$(VENV_BIN)/python -m queries.polars
 
 .PHONY: run-polars-no-env
-run-polars-no-env:  ## Run Polars benchmarks
+run-polars-no-env: data/tables/ ## Run Polars benchmarks
 	$(MAKE) -C tpch-dbgen dbgen
 	cd tpch-dbgen && ./dbgen -f -s $(SCALE_FACTOR) && cd ..
 	mkdir -p "data/tables/scale-$(SCALE_FACTOR)"
@@ -73,27 +73,27 @@ run-polars-no-env:  ## Run Polars benchmarks
 	python -m queries.polars
 
 .PHONY: run-polars-gpu-no-env
-run-polars-gpu-no-env: run-polars-no-env ## Run Polars CPU and GPU benchmarks
+run-polars-gpu-no-env: run-polars-no-env data/tables/ ## Run Polars CPU and GPU benchmarks
 	RUN_POLARS_GPU=true CUDA_MODULE_LOADING=EAGER python -m queries.polars
 
 .PHONY: run-duckdb
-run-duckdb: .venv  ## Run DuckDB benchmarks
+run-duckdb: .venv data/tables/ ## Run DuckDB benchmarks
 	$(VENV_BIN)/python -m queries.duckdb
 
 .PHONY: run-pandas
-run-pandas: .venv  ## Run pandas benchmarks
+run-pandas: .venv data/tables/ ## Run pandas benchmarks
 	$(VENV_BIN)/python -m queries.pandas
 
 .PHONY: run-pyspark
-run-pyspark: .venv  ## Run PySpark benchmarks
+run-pyspark: .venv data/tables/ ## Run PySpark benchmarks
 	$(VENV_BIN)/python -m queries.pyspark
 
 .PHONY: run-dask
-run-dask: .venv  ## Run Dask benchmarks
+run-dask: .venv data/tables/ ## Run Dask benchmarks
 	$(VENV_BIN)/python -m queries.dask
 
 .PHONY: run-modin
-run-modin: .venv  ## Run Modin benchmarks
+run-modin: .venv data/tables/ ## Run Modin benchmarks
 	$(VENV_BIN)/python -m queries.modin
 
 .PHONY: run-all

--- a/Makefile
+++ b/Makefile
@@ -76,23 +76,23 @@ run-polars-no-env:  ## Run Polars benchmarks
 run-polars-gpu-no-env: run-polars-no-env ## Run Polars CPU and GPU benchmarks
 	RUN_POLARS_GPU=true CUDA_MODULE_LOADING=EAGER python -m queries.polars
 
-.PHONY: run-duckdb data/tables/
+.PHONY: run-duckdb
 run-duckdb: .venv  ## Run DuckDB benchmarks
 	$(VENV_BIN)/python -m queries.duckdb
 
-.PHONY: run-pandas data/tables/
+.PHONY: run-pandas
 run-pandas: .venv  ## Run pandas benchmarks
 	$(VENV_BIN)/python -m queries.pandas
 
-.PHONY: run-pyspark data/tables/
+.PHONY: run-pyspark
 run-pyspark: .venv  ## Run PySpark benchmarks
 	$(VENV_BIN)/python -m queries.pyspark
 
-.PHONY: run-dask data/tables/
+.PHONY: run-dask
 run-dask: .venv  ## Run Dask benchmarks
 	$(VENV_BIN)/python -m queries.dask
 
-.PHONY: run-modin data/tables/
+.PHONY: run-modin
 run-modin: .venv  ## Run Modin benchmarks
 	$(VENV_BIN)/python -m queries.modin
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ You may not use PDS except in compliance with the Apache License, Version 2.0 an
 
 ```shell
 # clone this repository
-git clone https://github.com/pola-rs/pdsh.git
-cd tpch/tpch-dbgen
+git clone https://github.com/pola-rs/polars-benchmark.git
+cd polars-benchmark/tpch-dbgen
 
 # build tpch-dbgen
 make

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,6 @@ export RUN_LOG_TIMINGS=1
 export SCALE_FACTOR=1.0
 
 echo run with cached IO
-make tables
 make run-all
 make plot
 


### PR DESCRIPTION
This PR fixes a handful of typos:
- run.sh was making a non-existent target tables. The data is already generated in the data/tables target (transitively by run-all) so this can be removed
- The data/tables/ target was being redeclared as PHONY many times unnecessarily. I assume that the intent was to ensure that the data is a dependency of the run commands, so I moved the target name there
- The README links were out of date

Split out from #146 