### PR TITLE
Work around decimal scale mismatch in query 11 using an explicit cast

### DIFF
--- a/queries/polars/q11.py
+++ b/queries/polars/q11.py
@@ -41,6 +41,10 @@ def q(
             (pl.col("ps_supplycost") * pl.col("ps_availqty"))
             .sum()
             .round(2)
+            # TODO: Explicit cast required to align decimal scales.
+            # This cast avoids ComputeError: decimal[*,4] vs decimal[*,8]
+            # Remove once https://github.com/pola-rs/polars/issues/23063 is implemented.
+            .cast(pl.Decimal(20, 4))
             .alias("value")
         )
         .join(q2, how="cross")


### PR DESCRIPTION
This PR applies a `.cast(pl.Decimal(20, 4))` to avoid an "error" when comparing two decimal expressions with differing scales in query 11. I can't tell if the query if actually failing because the time seems reasonable. But I do see `q11 FAILED`

Currently result
```
$ SCALE_FACTOR=100 myenv/bin/python -m queries.polars.q11
Code block 'Run polars query 11' took: 1.71122 s
q11 FAILED
datatypes of join keys don't match - `value`: decimal[*,4] on left does not match `tmp`: decimal[*,8] on right
```
With this PR
```
$ SCALE_FACTOR=100 myenv/bin/python -m queries.polars.q11
Code block 'Run polars query 11' took: 1.82248 s
```