### PR TITLE
Fix calling `tpchgen-cli` in `.venv`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ else
 data/tables/.generated: .venv  ## Generate data tables
 	# use tpch-cli
 	mkdir -p "data/tables/scale-$(SCALE_FACTOR)"
-	tpchgen-cli --output-dir="data/tables/scale-$(SCALE_FACTOR)" --format=tbl -s $(SCALE_FACTOR)
+	$(VENV_BIN)/tpchgen-cli --output-dir="data/tables/scale-$(SCALE_FACTOR)" --format=tbl -s $(SCALE_FACTOR)
 	$(VENV_BIN)/python -m scripts.prepare_data --num-parts=1 --tpch_gen_folder="data/tables/scale-$(SCALE_FACTOR)"
 
 	# use tpch-dbgen


### PR DESCRIPTION
The `tpchgen-cli` binary is installed in `.venv/bin`, but it is invoked without the path. This only works if `.venv` is activated.

```bash
$ SCALE_FACTOR=1.0 make run-polars
...
mkdir -p "data/tables/scale-1.0"
tpchgen-cli --output-dir="data/tables/scale-1.0" --format=tbl -s 1.0
/bin/bash: Zeile 1: tpchgen-cli: Befehl nicht gefunden
make: *** [Makefile:53: data/tables/.generated] Fehler 127
```

Using `$(VENV_BIN)/tpchgen-cli` in the `Makefile` makes this robust and work without the virtual env activated.