### PR TITLE
Fix lint errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,5 +46,12 @@ jobs:
           pip install -r requirements-dev.txt
 
       # Allow untyped calls for older Python versions
-      - name: Run mypy
-        run: mypy
+      # Code in scripts/aws_glue.py requires PySpark<4
+      - name: Run mypy (PySpark from requirements.txt)
+        run: |
+          mypy --exclude scripts/aws_glue.py
+
+      - name: Run mypy (PySpark<4)
+        run: |
+          pip install "pyspark<4"
+          mypy

--- a/scripts/aws_glue.py
+++ b/scripts/aws_glue.py
@@ -4,6 +4,8 @@ import time
 from awsglue.context import GlueContext
 from awsglue.transforms import *  # noqa: F403
 from awsglue.utils import getResolvedOptions
+
+# this requires PySpark<4
 from pyspark.context import SparkContext
 
 # @params: [JOB_NAME]

--- a/scripts/pl_cloud.py
+++ b/scripts/pl_cloud.py
@@ -97,7 +97,7 @@ for i, q in enumerate(queries):
     print(f"run q{i}")
     start_time = time.time()
     try:
-        print(q.remote(ctx).distributed().show())  # type: ignore[attr-defined]
+        print(q.remote(ctx).distributed().show())
         execution_time = time.time() - start_time
         print(f"q{i} executed in: {execution_time:.2f} seconds")
         timings.append(execution_time)


### PR DESCRIPTION
AWS Glue does not support PySpark 4, so lint fails with `pyspark>=4`.
MyPy further complains about unused ignore in `scripts/pl_cloud.py`.