### PR TITLE
Rework partitioned data generation

### DIFF
--- a/queries/common_utils.py
+++ b/queries/common_utils.py
@@ -23,7 +23,15 @@ settings = Settings()
 def get_table_path(table_name: str) -> Path:
     """Return the path to the given table."""
     ext = settings.run.io_type if settings.run.include_io else "parquet"
-    return settings.dataset_base_dir / f"{table_name}.{ext}"
+    if settings.num_batches is None:
+        return settings.dataset_base_dir / f"{table_name}.{ext}"
+    return (
+        settings.dataset_base_dir
+        / str(settings.num_batches)
+        / table_name
+        / "*"
+        / f"part.{ext}"
+    )
 
 
 def log_query_timing(

--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -72,7 +72,9 @@ def pipelined_data_generation(
     base_path.mkdir(parents=True, exist_ok=True)
 
     num_dbgen_partitions = num_batches * parallelism
-    for batch_idx, part_indices in enumerate(batch(range(1, num_dbgen_partitions + 1), n=parallelism)):
+    for batch_idx, part_indices in enumerate(
+        batch(range(1, num_dbgen_partitions + 1), n=parallelism)
+    ):
         logger.info("Partition %s: Generating CSV files", part_indices)
         with Pool(parallelism) as process_pool:
             process_pool.starmap(
@@ -209,13 +211,18 @@ def gen_parquet(
         lf = lf.select(columns)
 
         if partitioned:
-            def partition_file_name(ctx):
+
+            def partition_file_name(ctx: pl.BasePartitionContext) -> pathlib.Path:
                 partition = f"{batch_idx}_{ctx.file_idx}"
                 (base_path / table_name / partition).mkdir(parents=True, exist_ok=True)  # noqa: B023
                 return pathlib.Path(partition) / "part.parquet"
 
             path = base_path / table_name
-            lf.sink_parquet(pl.PartitionMaxSize(path, file_path=partition_file_name, max_size=rows_per_file))
+            lf.sink_parquet(
+                pl.PartitionMaxSize(
+                    path, file_path=partition_file_name, max_size=rows_per_file
+                )
+            )
         else:
             path = base_path / f"{table_name}.parquet"
             lf.sink_parquet(path)
@@ -241,7 +248,11 @@ if __name__ == "__main__":
         type=int,
     )
     parser.add_argument(
-        "--num-batches", default=None, help="Number of batches used to generate the data", type=int, nargs="?"
+        "--num-batches",
+        default=None,
+        help="Number of batches used to generate the data",
+        type=int,
+        nargs="?",
     )
     parser.add_argument(
         "--aws-s3-sync-location",

--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -60,26 +60,25 @@ def gen_csv(part_idx: int, cachedir: str, scale_factor: float, num_parts: int) -
 def pipelined_data_generation(
     scratch_dir: str,
     scale_factor: float,
-    num_parts: int,
+    num_batches: int,
     aws_s3_sync_location: str,
     parallelism: int = 4,
     rows_per_file: int = 500_000,
 ) -> None:
-    assert num_parts > 1, "script should only be used if num_parts > 1"
-
     if aws_s3_sync_location.endswith("/"):
         aws_s3_sync_location = aws_s3_sync_location[:-1]
 
-    base_path = pathlib.Path(scratch_dir) / str(num_parts)
+    base_path = pathlib.Path(scratch_dir) / str(num_batches)
     base_path.mkdir(parents=True, exist_ok=True)
 
-    for i, part_indices in enumerate(batch(range(1, num_parts + 1), n=parallelism)):
+    num_dbgen_partitions = num_batches * parallelism
+    for batch_idx, part_indices in enumerate(batch(range(1, num_dbgen_partitions + 1), n=parallelism)):
         logger.info("Partition %s: Generating CSV files", part_indices)
         with Pool(parallelism) as process_pool:
             process_pool.starmap(
                 gen_csv,
                 [
-                    (part_idx, base_path, scale_factor, num_parts)
+                    (part_idx, base_path, scale_factor, num_dbgen_partitions)
                     for part_idx in part_indices
                 ],
             )
@@ -88,20 +87,13 @@ def pipelined_data_generation(
         for f in csv_files:
             shutil.move(f, base_path / pathlib.Path(f).name)
 
-        gen_parquet(base_path, rows_per_file, partitioned=True, iteration_offset=i)
+        gen_parquet(base_path, rows_per_file, partitioned=True, batch_idx=batch_idx)
         parquet_files = glob.glob(f"{base_path}/*.parquet")  # noqa: PTH207
-
-        # Exclude static tables except for first iteration
-        exclude_static_tables = (
-            ""
-            if i == 0
-            else " ".join([f'--exclude "*/{tbl}/*"' for tbl in STATIC_TABLES])
-        )
 
         if len(aws_s3_sync_location):
             subprocess.check_output(
                 shlex.split(
-                    f'aws s3 sync {scratch_dir} {aws_s3_sync_location}/scale-factor-{scale_factor} --exclude "*" --include "*.parquet" {exclude_static_tables}'
+                    f'aws s3 sync {scratch_dir} {aws_s3_sync_location}/scale-{scale_factor} --exclude "*" --include "*.parquet"'
                 )
             )
             for parquet_file in parquet_files:
@@ -197,9 +189,12 @@ def gen_parquet(
     base_path: pathlib.Path,
     rows_per_file: int = 500_000,
     partitioned: bool = False,
-    iteration_offset: int = 0,
+    batch_idx: int = 0,
 ) -> None:
     for table_name, columns in table_columns.items():
+        if table_name in STATIC_TABLES and batch_idx != 0:
+            continue
+
         path = base_path / f"{table_name}.tbl*"
 
         lf = pl.scan_csv(
@@ -214,9 +209,13 @@ def gen_parquet(
         lf = lf.select(columns)
 
         if partitioned:
-            (base_path / table_name).mkdir(parents=True, exist_ok=True)
-            path = base_path / table_name / f"{iteration_offset}_{{part}}.parquet"
-            lf.sink_parquet(pl.PartitionMaxSize(path, max_size=rows_per_file))
+            def partition_file_name(ctx):
+                partition = f"{batch_idx}_{ctx.file_idx}"
+                (base_path / table_name / partition).mkdir(parents=True, exist_ok=True)  # noqa: B023
+                return pathlib.Path(partition) / "part.parquet"
+
+            path = base_path / table_name
+            lf.sink_parquet(pl.PartitionMaxSize(path, file_path=partition_file_name, max_size=rows_per_file))
         else:
             path = base_path / f"{table_name}.parquet"
             lf.sink_parquet(path)
@@ -242,7 +241,7 @@ if __name__ == "__main__":
         type=int,
     )
     parser.add_argument(
-        "--num-parts", default=32, help="Number of parts to generate", type=int
+        "--num-batches", default=None, help="Number of batches used to generate the data", type=int, nargs="?"
     )
     parser.add_argument(
         "--aws-s3-sync-location",
@@ -257,7 +256,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    if args.num_parts == 1:
+    if args.num_batches is None:
         # Assumes the tables are already created by the Makefile
         gen_parquet(
             pathlib.Path(args.tpch_gen_folder),
@@ -268,7 +267,7 @@ if __name__ == "__main__":
         pipelined_data_generation(
             args.tpch_gen_folder,
             args.scale_factor,
-            args.num_parts,
+            args.num_batches,
             args.aws_s3_sync_location,
             parallelism=args.parallelism,
             rows_per_file=args.rows_per_file,

--- a/settings.py
+++ b/settings.py
@@ -77,6 +77,7 @@ class Plot(BaseSettings):
 
 class Settings(BaseSettings):
     scale_factor: float = 1.0
+    num_batches: int | None = None
 
     paths: Paths = Paths()
     plot: Plot = Plot()


### PR DESCRIPTION
There is currently no way to control the number of partitions, as they are split based on number of lines. What can be controlled the number of batches the tbl files are generated in, and the paralellism used for each batch. The result is as many partitions needed for each batch as there are rows per table.

Fixes:
- use of PartitionMaxSize
- bucket name when syncing to AWS S3
- puts each parquet file into its own directory, syncing this to S3 improves read throughput
as AWS throttles bandwith per prefix (directory)