### PR TITLE
Reenable DuckDB typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,6 @@ module = [
   "awsglue.*",
   "scripts/aws_glue.py",
   "scripts/aws_emr.py",
-  # TODO: Remove after https://github.com/duckdb/duckdb-python/issues/57 is resolved
-  "duckdb.*",
 ]
 ignore_missing_imports = true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ dask==2025.9.1
     #   dask-expr
 dask-expr==2.0.0
     # via -r requirements.in
-duckdb==1.4.0
+duckdb==1.4.1
     # via -r requirements.in
 fastparquet==2024.11.0
     # via -r requirements.in


### PR DESCRIPTION
In #173 I disabled DuckDB typing due to https://github.com/duckdb/duckdb-python/issues/57. That issue [is now fixed](https://github.com/duckdb/duckdb-python/issues/57#issuecomment-3360776767) and available in a [dev release of DuckDB](https://pypi.org/project/duckdb/1.4.1.dev135/). I installed that version locally and verified that mypy runs successfully with no errors. We can merge this PR as soon as DuckDB 1.4.1 is released, which is supposed to be today.