### PR TITLE
Replace left join + is_null() with anti join

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ perf.*
 **/flamegraph.svg
 
 # Other
+.DS_Store
 .swp
 *.tbl
 *.o

--- a/queries/polars/q16.py
+++ b/queries/polars/q16.py
@@ -33,8 +33,7 @@ def q(
         .filter(pl.col("p_brand") != var1)
         .filter(pl.col("p_type").str.contains("MEDIUM POLISHED*").not_())
         .filter(pl.col("p_size").is_in([49, 14, 23, 45, 19, 3, 36, 9]))
-        .join(supplier, left_on="ps_suppkey", right_on="s_suppkey", how="left")
-        .filter(pl.col("ps_suppkey_right").is_null())
+        .join(supplier, left_on="ps_suppkey", right_on="s_suppkey", how="anti")
         .group_by("p_brand", "p_type", "p_size")
         .agg(pl.col("ps_suppkey").n_unique().alias("supplier_cnt"))
         .sort(

--- a/queries/polars/q22.py
+++ b/queries/polars/q22.py
@@ -29,13 +29,8 @@ def q(
         pl.col("c_acctbal").mean().alias("avg_acctbal")
     )
 
-    q3 = orders.select(pl.col("o_custkey").unique()).with_columns(
-        pl.col("o_custkey").alias("c_custkey")
-    )
-
     return (
-        q1.join(q3, on="c_custkey", how="left")
-        .filter(pl.col("o_custkey").is_null())
+        q1.join(orders, left_on="c_custkey", right_on="o_custkey", how="anti")
         .join(q2, how="cross")
         .filter(pl.col("c_acctbal") > pl.col("avg_acctbal"))
         .group_by("cntrycode")


### PR DESCRIPTION
Instead of doing a left join and then filtering with .is_null() do an anti join straight away.

Benchmarked with claude:

  Performance vs. left-join (main branch)

```
  ┌───────┬─────────────┬─────────────┬──────────────┬──────────────┬──────────────────┐
  │ Query │ SF=1 (anti) │ SF=1 (left) │ SF=10 (anti) │ SF=10 (left) │ Speedup at SF=10 │
  ├───────┼─────────────┼─────────────┼──────────────┼──────────────┼──────────────────┤
  │ Q16   │ 7.9 ms      │ 6.9 ms      │ 39.6 ms      │ 42.0 ms      │ 1.06x faster     │
  ├───────┼─────────────┼─────────────┼──────────────┼──────────────┼──────────────────┤
  │ Q22   │ 14.1 ms     │ 16.0 ms     │ 61.7 ms      │ 86.7 ms      │ 1.40x faster     │
  └───────┴─────────────┴─────────────┴──────────────┴──────────────┴──────────────────┘
  ```

Benchmark passes when run with `SCALE_FACTOR=1 RUN_CHECK_RESULTS=1`

TPC-H specs show this SQL query for Q16:

<img width="1235" height="1066" alt="image" src="https://github.com/user-attachments/assets/93bbda98-8ede-48ce-9ce3-f4942f869486" />

TPC-H specs show this SQL query for Q22:

<img width="957" height="1135" alt="image" src="https://github.com/user-attachments/assets/550fbaba-83ea-473a-adb3-0abe49242f36" />

I'd argue a "where not exists" and "not in" is more likely to be read as an anti-join than first left joining everything and then filtering out the rows that don't have an entry of the joined table. Thus not falling under optimization against the benchmark's spirit.