### PR TITLE
refactor: Prefer consistent use of "function" pattern instead of `nonlocal`

### DIFF
--- a/queries/dask/q1.py
+++ b/queries/dask/q1.py
@@ -10,13 +10,12 @@ Q_NUM = 1
 
 
 def q() -> None:
-    line_item_ds = utils.get_line_item_ds
+    line_item_ds_fn = utils.get_line_item_ds
     # first call one time to cache in case we don't include the IO times
-    line_item_ds()
+    line_item_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal line_item_ds
-        line_item_ds = line_item_ds()
+        line_item_ds = line_item_ds_fn()
 
         var1 = date(1998, 9, 2)
 

--- a/queries/dask/q2.py
+++ b/queries/dask/q2.py
@@ -11,30 +11,25 @@ Q_NUM = 2
 
 
 def q() -> None:
-    region_ds = utils.get_region_ds
-    nation_ds = utils.get_nation_ds
-    supplier_ds = utils.get_supplier_ds
-    part_ds = utils.get_part_ds
-    part_supp_ds = utils.get_part_supp_ds
+    region_ds_fn = utils.get_region_ds
+    nation_ds_fn = utils.get_nation_ds
+    supplier_ds_fn = utils.get_supplier_ds
+    part_ds_fn = utils.get_part_ds
+    part_supp_ds_fn = utils.get_part_supp_ds
 
     # first call one time to cache in case we don't include the IO times
-    region_ds()
-    nation_ds()
-    supplier_ds()
-    part_ds()
-    part_supp_ds()
+    region_ds_fn()
+    nation_ds_fn()
+    supplier_ds_fn()
+    part_ds_fn()
+    part_supp_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal region_ds
-        nonlocal nation_ds
-        nonlocal supplier_ds
-        nonlocal part_ds
-        nonlocal part_supp_ds
-        region_ds = region_ds()
-        nation_ds = nation_ds()
-        supplier_ds = supplier_ds()
-        part_ds = part_ds()
-        part_supp_ds = part_supp_ds()
+        region_ds = region_ds_fn()
+        nation_ds = nation_ds_fn()
+        supplier_ds = supplier_ds_fn()
+        part_ds = part_ds_fn()
+        part_supp_ds = part_supp_ds_fn()
 
         var1 = 15
         var2 = "BRASS"

--- a/queries/dask/q3.py
+++ b/queries/dask/q3.py
@@ -12,22 +12,19 @@ Q_NUM = 3
 
 
 def q() -> None:
-    customer_ds = utils.get_customer_ds
-    line_item_ds = utils.get_line_item_ds
-    orders_ds = utils.get_orders_ds
+    customer_ds_fn = utils.get_customer_ds
+    line_item_ds_fn = utils.get_line_item_ds
+    orders_ds_fn = utils.get_orders_ds
 
     # first call one time to cache in case we don't include the IO times
-    customer_ds()
-    line_item_ds()
-    orders_ds()
+    customer_ds_fn()
+    line_item_ds_fn()
+    orders_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal customer_ds
-        nonlocal line_item_ds
-        nonlocal orders_ds
-        customer_ds = customer_ds()
-        line_item_ds = line_item_ds()
-        orders_ds = orders_ds()
+        customer_ds = customer_ds_fn()
+        line_item_ds = line_item_ds_fn()
+        orders_ds = orders_ds_fn()
 
         var1 = "BUILDING"
         var2 = date(1995, 3, 15)

--- a/queries/dask/q4.py
+++ b/queries/dask/q4.py
@@ -10,18 +10,16 @@ Q_NUM = 4
 
 
 def q() -> None:
-    line_item_ds = utils.get_line_item_ds
-    orders_ds = utils.get_orders_ds
+    line_item_ds_fn = utils.get_line_item_ds
+    orders_ds_fn = utils.get_orders_ds
 
     # first call one time to cache in case we don't include the IO times
-    line_item_ds()
-    orders_ds()
+    line_item_ds_fn()
+    orders_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal line_item_ds
-        nonlocal orders_ds
-        line_item_ds = line_item_ds()
-        orders_ds = orders_ds()
+        line_item_ds = line_item_ds_fn()
+        orders_ds = orders_ds_fn()
 
         var1 = date(1993, 7, 1)
         var2 = date(1993, 10, 1)

--- a/queries/dask/q5.py
+++ b/queries/dask/q5.py
@@ -12,34 +12,28 @@ Q_NUM = 5
 
 
 def q() -> None:
-    region_ds = utils.get_region_ds
-    nation_ds = utils.get_nation_ds
-    customer_ds = utils.get_customer_ds
-    line_item_ds = utils.get_line_item_ds
-    orders_ds = utils.get_orders_ds
-    supplier_ds = utils.get_supplier_ds
+    region_ds_fn = utils.get_region_ds
+    nation_ds_fn = utils.get_nation_ds
+    customer_ds_fn = utils.get_customer_ds
+    line_item_ds_fn = utils.get_line_item_ds
+    orders_ds_fn = utils.get_orders_ds
+    supplier_ds_fn = utils.get_supplier_ds
 
     # first call one time to cache in case we don't include the IO times
-    region_ds()
-    nation_ds()
-    customer_ds()
-    line_item_ds()
-    orders_ds()
-    supplier_ds()
+    region_ds_fn()
+    nation_ds_fn()
+    customer_ds_fn()
+    line_item_ds_fn()
+    orders_ds_fn()
+    supplier_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal region_ds
-        nonlocal nation_ds
-        nonlocal customer_ds
-        nonlocal line_item_ds
-        nonlocal orders_ds
-        nonlocal supplier_ds
-        region_ds = region_ds()
-        nation_ds = nation_ds()
-        customer_ds = customer_ds()
-        line_item_ds = line_item_ds()
-        orders_ds = orders_ds()
-        supplier_ds = supplier_ds()
+        region_ds = region_ds_fn()
+        nation_ds = nation_ds_fn()
+        customer_ds = customer_ds_fn()
+        line_item_ds = line_item_ds_fn()
+        orders_ds = orders_ds_fn()
+        supplier_ds = supplier_ds_fn()
 
         var1 = "ASIA"
         var2 = date(1994, 1, 1)

--- a/queries/dask/q6.py
+++ b/queries/dask/q6.py
@@ -10,14 +10,13 @@ Q_NUM = 6
 
 
 def q() -> None:
-    line_item_ds = utils.get_line_item_ds
+    line_item_ds_fn = utils.get_line_item_ds
 
     # first call one time to cache in case we don't include the IO times
-    line_item_ds()
+    line_item_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal line_item_ds
-        line_item_ds = line_item_ds()
+        line_item_ds = line_item_ds_fn()
 
         var1 = date(1994, 1, 1)
         var2 = date(1995, 1, 1)

--- a/queries/dask/q7.py
+++ b/queries/dask/q7.py
@@ -16,30 +16,25 @@ Q_NUM = 7
 
 
 def q() -> None:
-    nation_ds = utils.get_nation_ds
-    customer_ds = utils.get_customer_ds
-    line_item_ds = utils.get_line_item_ds
-    orders_ds = utils.get_orders_ds
-    supplier_ds = utils.get_supplier_ds
+    nation_ds_fn = utils.get_nation_ds
+    customer_ds_fn = utils.get_customer_ds
+    line_item_ds_fn = utils.get_line_item_ds
+    orders_ds_fn = utils.get_orders_ds
+    supplier_ds_fn = utils.get_supplier_ds
 
     # first call one time to cache in case we don't include the IO times
-    nation_ds()
-    customer_ds()
-    line_item_ds()
-    orders_ds()
-    supplier_ds()
+    nation_ds_fn()
+    customer_ds_fn()
+    line_item_ds_fn()
+    orders_ds_fn()
+    supplier_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal nation_ds
-        nonlocal customer_ds
-        nonlocal line_item_ds
-        nonlocal orders_ds
-        nonlocal supplier_ds
-        nation_ds = nation_ds()
-        customer_ds = customer_ds()
-        line_item_ds = line_item_ds()
-        orders_ds = orders_ds()
-        supplier_ds = supplier_ds()
+        nation_ds = nation_ds_fn()
+        customer_ds = customer_ds_fn()
+        line_item_ds = line_item_ds_fn()
+        orders_ds = orders_ds_fn()
+        supplier_ds = supplier_ds_fn()
 
         var1 = "FRANCE"
         var2 = "GERMANY"

--- a/queries/modin/q1.py
+++ b/queries/modin/q1.py
@@ -10,13 +10,12 @@ Q_NUM = 1
 
 
 def q() -> None:
-    line_item_ds = utils.get_line_item_ds
+    line_item_ds_fn = utils.get_line_item_ds
     # first call one time to cache in case we don't include the IO times
-    line_item_ds()
+    line_item_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal line_item_ds
-        line_item_ds = line_item_ds()
+        line_item_ds = line_item_ds_fn()
 
         var1 = date(1998, 9, 2)
 

--- a/queries/modin/q2.py
+++ b/queries/modin/q2.py
@@ -11,30 +11,25 @@ Q_NUM = 2
 
 
 def q() -> None:
-    region_ds = utils.get_region_ds
-    nation_ds = utils.get_nation_ds
-    supplier_ds = utils.get_supplier_ds
-    part_ds = utils.get_part_ds
-    part_supp_ds = utils.get_part_supp_ds
+    region_ds_fn = utils.get_region_ds
+    nation_ds_fn = utils.get_nation_ds
+    supplier_ds_fn = utils.get_supplier_ds
+    part_ds_fn = utils.get_part_ds
+    part_supp_ds_fn = utils.get_part_supp_ds
 
     # first call one time to cache in case we don't include the IO times
-    region_ds()
-    nation_ds()
-    supplier_ds()
-    part_ds()
-    part_supp_ds()
+    region_ds_fn()
+    nation_ds_fn()
+    supplier_ds_fn()
+    part_ds_fn()
+    part_supp_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal region_ds
-        nonlocal nation_ds
-        nonlocal supplier_ds
-        nonlocal part_ds
-        nonlocal part_supp_ds
-        region_ds = region_ds()
-        nation_ds = nation_ds()
-        supplier_ds = supplier_ds()
-        part_ds = part_ds()
-        part_supp_ds = part_supp_ds()
+        region_ds = region_ds_fn()
+        nation_ds = nation_ds_fn()
+        supplier_ds = supplier_ds_fn()
+        part_ds = part_ds_fn()
+        part_supp_ds = part_supp_ds_fn()
 
         var1 = 15
         var2 = "BRASS"

--- a/queries/modin/q3.py
+++ b/queries/modin/q3.py
@@ -12,22 +12,19 @@ Q_NUM = 3
 
 
 def q() -> None:
-    customer_ds = utils.get_customer_ds
-    line_item_ds = utils.get_line_item_ds
-    orders_ds = utils.get_orders_ds
+    customer_ds_fn = utils.get_customer_ds
+    line_item_ds_fn = utils.get_line_item_ds
+    orders_ds_fn = utils.get_orders_ds
 
     # first call one time to cache in case we don't include the IO times
-    customer_ds()
-    line_item_ds()
-    orders_ds()
+    customer_ds_fn()
+    line_item_ds_fn()
+    orders_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal customer_ds
-        nonlocal line_item_ds
-        nonlocal orders_ds
-        customer_ds = customer_ds()
-        line_item_ds = line_item_ds()
-        orders_ds = orders_ds()
+        customer_ds = customer_ds_fn()
+        line_item_ds = line_item_ds_fn()
+        orders_ds = orders_ds_fn()
 
         var1 = "BUILDING"
         var2 = date(1995, 3, 15)

--- a/queries/modin/q4.py
+++ b/queries/modin/q4.py
@@ -10,18 +10,16 @@ Q_NUM = 4
 
 
 def q() -> None:
-    line_item_ds = utils.get_line_item_ds
-    orders_ds = utils.get_orders_ds
+    line_item_ds_fn = utils.get_line_item_ds
+    orders_ds_fn = utils.get_orders_ds
 
     # first call one time to cache in case we don't include the IO times
-    line_item_ds()
-    orders_ds()
+    line_item_ds_fn()
+    orders_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal line_item_ds
-        nonlocal orders_ds
-        line_item_ds = line_item_ds()
-        orders_ds = orders_ds()
+        line_item_ds = line_item_ds_fn()
+        orders_ds = orders_ds_fn()
 
         var1 = date(1993, 7, 1)
         var2 = date(1993, 10, 1)

--- a/queries/modin/q5.py
+++ b/queries/modin/q5.py
@@ -12,34 +12,28 @@ Q_NUM = 5
 
 
 def q() -> None:
-    region_ds = utils.get_region_ds
-    nation_ds = utils.get_nation_ds
-    customer_ds = utils.get_customer_ds
-    line_item_ds = utils.get_line_item_ds
-    orders_ds = utils.get_orders_ds
-    supplier_ds = utils.get_supplier_ds
+    region_ds_fn = utils.get_region_ds
+    nation_ds_fn = utils.get_nation_ds
+    customer_ds_fn = utils.get_customer_ds
+    line_item_ds_fn = utils.get_line_item_ds
+    orders_ds_fn = utils.get_orders_ds
+    supplier_ds_fn = utils.get_supplier_ds
 
     # first call one time to cache in case we don't include the IO times
-    region_ds()
-    nation_ds()
-    customer_ds()
-    line_item_ds()
-    orders_ds()
-    supplier_ds()
+    region_ds_fn()
+    nation_ds_fn()
+    customer_ds_fn()
+    line_item_ds_fn()
+    orders_ds_fn()
+    supplier_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal region_ds
-        nonlocal nation_ds
-        nonlocal customer_ds
-        nonlocal line_item_ds
-        nonlocal orders_ds
-        nonlocal supplier_ds
-        region_ds = region_ds()
-        nation_ds = nation_ds()
-        customer_ds = customer_ds()
-        line_item_ds = line_item_ds()
-        orders_ds = orders_ds()
-        supplier_ds = supplier_ds()
+        region_ds = region_ds_fn()
+        nation_ds = nation_ds_fn()
+        customer_ds = customer_ds_fn()
+        line_item_ds = line_item_ds_fn()
+        orders_ds = orders_ds_fn()
+        supplier_ds = supplier_ds_fn()
 
         var1 = "ASIA"
         var2 = date(1994, 1, 1)

--- a/queries/modin/q6.py
+++ b/queries/modin/q6.py
@@ -10,14 +10,13 @@ Q_NUM = 6
 
 
 def q() -> None:
-    line_item_ds = utils.get_line_item_ds
+    line_item_ds_fn = utils.get_line_item_ds
 
     # first call one time to cache in case we don't include the IO times
-    line_item_ds()
+    line_item_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal line_item_ds
-        line_item_ds = line_item_ds()
+        line_item_ds = line_item_ds_fn()
 
         var1 = date(1994, 1, 1)
         var2 = date(1995, 1, 1)

--- a/queries/modin/q7.py
+++ b/queries/modin/q7.py
@@ -10,30 +10,25 @@ Q_NUM = 7
 
 
 def q() -> None:
-    nation_ds = utils.get_nation_ds
-    customer_ds = utils.get_customer_ds
-    line_item_ds = utils.get_line_item_ds
-    orders_ds = utils.get_orders_ds
-    supplier_ds = utils.get_supplier_ds
+    nation_ds_fn = utils.get_nation_ds
+    customer_ds_fn = utils.get_customer_ds
+    line_item_ds_fn = utils.get_line_item_ds
+    orders_ds_fn = utils.get_orders_ds
+    supplier_ds_fn = utils.get_supplier_ds
 
     # first call one time to cache in case we don't include the IO times
-    nation_ds()
-    customer_ds()
-    line_item_ds()
-    orders_ds()
-    supplier_ds()
+    nation_ds_fn()
+    customer_ds_fn()
+    line_item_ds_fn()
+    orders_ds_fn()
+    supplier_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal nation_ds
-        nonlocal customer_ds
-        nonlocal line_item_ds
-        nonlocal orders_ds
-        nonlocal supplier_ds
-        nation_ds = nation_ds()
-        customer_ds = customer_ds()
-        line_item_ds = line_item_ds()
-        orders_ds = orders_ds()
-        supplier_ds = supplier_ds()
+        nation_ds = nation_ds_fn()
+        customer_ds = customer_ds_fn()
+        line_item_ds = line_item_ds_fn()
+        orders_ds = orders_ds_fn()
+        supplier_ds = supplier_ds_fn()
 
         var1 = "FRANCE"
         var2 = "GERMANY"

--- a/queries/modin/q8.py
+++ b/queries/modin/q8.py
@@ -12,38 +12,31 @@ Q_NUM = 8
 
 
 def q() -> None:
-    customer_ds = utils.get_customer_ds
-    line_item_ds = utils.get_line_item_ds
-    nation_ds = utils.get_nation_ds
-    orders_ds = utils.get_orders_ds
-    part_ds = utils.get_part_ds
-    region_ds = utils.get_region_ds
-    supplier_ds = utils.get_supplier_ds
+    customer_ds_fn = utils.get_customer_ds
+    line_item_ds_fn = utils.get_line_item_ds
+    nation_ds_fn = utils.get_nation_ds
+    orders_ds_fn = utils.get_orders_ds
+    part_ds_fn = utils.get_part_ds
+    region_ds_fn = utils.get_region_ds
+    supplier_ds_fn = utils.get_supplier_ds
 
     # first call one time to cache in case we don't include the IO times
-    customer_ds()
-    line_item_ds()
-    nation_ds()
-    orders_ds()
-    part_ds()
-    region_ds()
-    supplier_ds()
+    customer_ds_fn()
+    line_item_ds_fn()
+    nation_ds_fn()
+    orders_ds_fn()
+    part_ds_fn()
+    region_ds_fn()
+    supplier_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal customer_ds
-        nonlocal line_item_ds
-        nonlocal nation_ds
-        nonlocal orders_ds
-        nonlocal part_ds
-        nonlocal region_ds
-        nonlocal supplier_ds
-        customer_ds = customer_ds()
-        line_item_ds = line_item_ds()
-        nation_ds = nation_ds()
-        orders_ds = orders_ds()
-        part_ds = part_ds()
-        region_ds = region_ds()
-        supplier_ds = supplier_ds()
+        customer_ds = customer_ds_fn()
+        line_item_ds = line_item_ds_fn()
+        nation_ds = nation_ds_fn()
+        orders_ds = orders_ds_fn()
+        part_ds = part_ds_fn()
+        region_ds = region_ds_fn()
+        supplier_ds = supplier_ds_fn()
 
         var1 = "BRAZIL"
         var2 = "AMERICA"

--- a/queries/modin/utils.py
+++ b/queries/modin/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from typing import TYPE_CHECKING, Any
 
 import modin.pandas as pd
@@ -20,7 +21,16 @@ settings = Settings()
 
 pd.options.mode.copy_on_write = True
 
-os.environ["MODIN_MEMORY"] = str(settings.run.modin_memory)
+# Ray (Modin's engine) won't start properly with an object store larger than 2GB on
+# macOS, where its performance is known to degrade beyond that point; this value
+# comes from `ray._private.ray_constants.MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT`
+MAC_OBJECT_STORE_LIMIT = 2 * 1024**3
+
+modin_memory = settings.run.modin_memory
+if sys.platform == "darwin":
+    modin_memory = min(modin_memory, MAC_OBJECT_STORE_LIMIT)
+
+os.environ["MODIN_MEMORY"] = str(modin_memory)
 
 
 def _read_ds(table_name: str) -> pd.DataFrame:


### PR DESCRIPTION
Made the function pattern consistent across all benchmarks - the `nonlocal` overwrite can cause issues with multiple runs in a single session. We already use the function pattern in an other queries/tests, so this is consistent as well as fixing some edge-cases.

~Also fixes some benchmarks running on macOS (ref: "MODIN_MEMORY" env).~